### PR TITLE
Ulauncher 6 (API v3) migration

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,13 +48,6 @@ class FuzzyFinderExtension(Extension):
         if ignore_file and not path.isfile(path.expanduser(ignore_file)):
             errors.append(f"Ignore file '{ignore_file}' is not a file.")
 
-        try:
-            result_limit = int(preferences["result_limit"])
-            if result_limit <= 0:
-                errors.append("Result limit must be greater than 0.")
-        except ValueError:
-            errors.append("Result limit must be an integer.")
-
         if not errors:
             logger.debug("User preferences validated")
 
@@ -64,6 +57,8 @@ class FuzzyFinderExtension(Extension):
     def get_preferences(input_preferences: ExtensionPreferences) -> FuzzyFinderPreferences:
         preferences: FuzzyFinderPreferences = {
             "search_type": SearchType(int(input_preferences["search_type"])),
+            # type casting for allow_hidden and result_limit is only needed to support
+            # preferences saved before the extension API v3 migration
             "allow_hidden": bool(int(input_preferences["allow_hidden"])),
             "result_limit": int(input_preferences["result_limit"]),
             "base_dir": path.expanduser(input_preferences["base_dir"]),

--- a/main.py
+++ b/main.py
@@ -5,14 +5,12 @@ from enum import Enum
 from os import path
 from typing import Any, Dict, List, Tuple
 
+from ulauncher.api import Extension, ExtensionResult, ExtensionSmallResult
 from ulauncher.api.client.EventListener import EventListener
-from ulauncher.api.client.Extension import Extension
 from ulauncher.api.shared.action.DoNothingAction import DoNothingAction
 from ulauncher.api.shared.action.OpenAction import OpenAction
 from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
 from ulauncher.api.shared.event import KeywordQueryEvent
-from ulauncher.api.shared.item.ExtensionResultItem import ExtensionResultItem
-from ulauncher.api.shared.item.ExtensionSmallResultItem import ExtensionSmallResultItem
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +142,7 @@ class KeywordQueryEventListener(EventListener):
     @staticmethod
     def no_op_result_items(msgs: List[str], icon: str = "icon") -> RenderResultListAction:
         def create_result_item(msg):
-            return ExtensionResultItem(
+            return ExtensionResult(
                 icon=f"images/{icon}.png",
                 name=msg,
                 on_enter=DoNothingAction(),
@@ -178,7 +176,7 @@ class KeywordQueryEventListener(EventListener):
             return self.no_op_result_items(["There was an error running this extension."], "error")
 
         def create_result_item(filename):
-            return ExtensionSmallResultItem(
+            return ExtensionSmallResult(
                 icon="images/sub-icon.png",
                 name=filename,
                 on_enter=OpenAction(filename),

--- a/main.py
+++ b/main.py
@@ -9,7 +9,6 @@ from ulauncher.api import Extension, ExtensionResult, ExtensionSmallResult
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.shared.action.DoNothingAction import DoNothingAction
 from ulauncher.api.shared.action.OpenAction import OpenAction
-from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
 from ulauncher.api.shared.event import KeywordQueryEvent
 
 logger = logging.getLogger(__name__)
@@ -140,7 +139,7 @@ class KeywordQueryEventListener(EventListener):
         return dirname
 
     @staticmethod
-    def no_op_result_items(msgs: List[str], icon: str = "icon") -> RenderResultListAction:
+    def no_op_result_items(msgs: List[str], icon: str = "icon") -> List[ExtensionResult]:
         def create_result_item(msg):
             return ExtensionResult(
                 icon=f"images/{icon}.png",
@@ -148,12 +147,11 @@ class KeywordQueryEventListener(EventListener):
                 on_enter=DoNothingAction(),
             )
 
-        items = list(map(create_result_item, msgs))
-        return RenderResultListAction(items)
+        return list(map(create_result_item, msgs))
 
     def on_event(
         self, event: KeywordQueryEvent, extension: FuzzyFinderExtension
-    ) -> RenderResultListAction:
+    ) -> List[ExtensionResult]:
         bin_names, errors = extension.get_binaries()
         errors.extend(extension.check_preferences(extension.preferences))
         if errors:
@@ -183,8 +181,7 @@ class KeywordQueryEventListener(EventListener):
                 on_alt_enter=OpenAction(self.get_dirname(filename)),
             )
 
-        items = list(map(create_result_item, results))
-        return RenderResultListAction(items)
+        return list(map(create_result_item, results))
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -6,10 +6,9 @@ from os import path
 from typing import Any, Dict, List, Tuple
 
 from ulauncher.api import Extension, ExtensionResult, ExtensionSmallResult
-from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.shared.action.DoNothingAction import DoNothingAction
 from ulauncher.api.shared.action.OpenAction import OpenAction
-from ulauncher.api.shared.event import KeywordQueryEvent
+from ulauncher.api.shared.query import Query
 
 logger = logging.getLogger(__name__)
 
@@ -26,10 +25,6 @@ FuzzyFinderPreferences = Dict[str, Any]
 
 
 class FuzzyFinderExtension(Extension):
-    def __init__(self):
-        super().__init__()
-        self.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
-
     @staticmethod
     def assign_bin_name(bin_names: BinNames, bin_cmd: str, testing_cmd: str) -> BinNames:
         try:
@@ -131,8 +126,6 @@ class FuzzyFinderExtension(Extension):
 
             return results
 
-
-class KeywordQueryEventListener(EventListener):
     @staticmethod
     def get_dirname(filename: str) -> str:
         dirname = filename if path.isdir(filename) else path.dirname(filename)
@@ -149,22 +142,19 @@ class KeywordQueryEventListener(EventListener):
 
         return list(map(create_result_item, msgs))
 
-    def on_event(
-        self, event: KeywordQueryEvent, extension: FuzzyFinderExtension
-    ) -> List[ExtensionResult]:
-        bin_names, errors = extension.get_binaries()
-        errors.extend(extension.check_preferences(extension.preferences))
+    def on_query_change(self, query: Query) -> List[ExtensionResult]:
+        bin_names, errors = self.get_binaries()
+        errors.extend(self.check_preferences(self.preferences))
         if errors:
             return self.no_op_result_items(errors, "error")
 
-        query = event.get_argument()
         if not query:
             return self.no_op_result_items(["Enter your search criteria."])
 
-        preferences = extension.get_preferences(extension.preferences)
+        preferences = self.get_preferences(self.preferences)
 
         try:
-            results = extension.search(query, preferences, **bin_names)
+            results = self.search(query, preferences, **bin_names)
         except subprocess.CalledProcessError as error:
             failing_cmd = error.cmd[0]
             if failing_cmd == "fzf" and error.returncode == 1:

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "required_api_version": "^2.0.0",
+  "required_api_version": "3",
   "name": "Fuzzy Finder",
   "description": "Find files and directories in Ulauncher using fzf",
   "developer_name": "Hillary Chan",

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "description": "Find files and directories in Ulauncher using fzf",
   "developer_name": "Hillary Chan",
   "icon": "images/icon.png",
+  "instructions": "This extensions needs <code>fzf</code> and <code>fd</code> (note that fd is called <code>fdfind</code> in some package managers).",
   "options": {
     "query_debounce": 0.5
   },

--- a/manifest.json
+++ b/manifest.json
@@ -38,27 +38,17 @@
     },
     {
       "id": "allow_hidden",
-      "type": "select",
+      "type": "checkbox",
       "name": "Allow hidden files and directories",
-      "description": "Set whether hidden files and directories should be included when searching.",
-      "default_value": 0,
-      "options": [
-        {
-          "text": "No",
-          "value": 0
-        },
-        {
-          "text": "Yes",
-          "value": 1
-        }
-      ]
+      "description": "Set whether hidden files and directories should be included when searching."
     },
     {
       "id": "result_limit",
-      "type": "input",
+      "type": "number",
       "name": "Result limit",
       "description": "Number of results that should be returned.",
-      "default_value": "15"
+      "min": 1,
+      "default_value": 15
     },
     {
       "id": "base_dir",

--- a/versions.json
+++ b/versions.json
@@ -1,1 +1,1 @@
-[{ "required_api_version": "^2.0.0", "commit": "main" }]
+[{ "required_api_version": "2", "commit": "a2d2d4e" }]


### PR DESCRIPTION
This PR is to demonstrate the capabilities of Ulauncher 6 and how to migrate extensions. I picked `ulauncher-fzf` as I remember it had implementation details that would make it a good example for this.

It's not actually a PR meant for [upstream](https://github.com/hillaryychan/ulauncher-fzf) **yet**, since v6 isn't out yet, and the API version is still `"2"` (will be bumped to `"3"` before release).

See https://github.com/Ulauncher/Ulauncher/issues/1062